### PR TITLE
AI move tie odds fix

### DIFF
--- a/calc/src/ai.ts
+++ b/calc/src/ai.ts
@@ -60,7 +60,7 @@ const powderMoves: string[] = [
     "Cotton Spore", "Magic Powder", "Poison Powder", "Powder", "Rage Powder", "Sleep Powder", "Spore", "Stun Spore"
 ];
 const statusApplyingMoves: string[] = [
-    "Grass Whistle", "Sleep Powder", "Lovely Kiss"
+    "Grass Whistle", "Sleep Powder", "Lovely Kiss", "Spore"
 ];
 const defrostingMoves: string[] = [
     "Burn Up", "Flame Wheel", "Flare Blitz", "Fusion Flare", "Pyro Ball", "Sacred Fire", "Scald", "Scorching Sands", "Steam Eruption"

--- a/calc/src/ai.ts
+++ b/calc/src/ai.ts
@@ -252,44 +252,30 @@ function cartesian(arrays: any[][]): any[][] {
     }, [[]]);
 }
 
-function setKeyStrings(keyString: string, splitKeys: string[]) : string[] {
-    let keyStrings: string[] = [];
-    for (let splitKey in splitKeys) {
-        if (keyString.includes(splitKey)) {
-            keyStrings.push(...splitKeyString(keyString, splitKey));
+function splitHighestDamageTies(keyString: string): string[] {
+    const parts = keyString.split("/");
+    const tiedHighestDamageIndexes = parts.reduce((indexes: number[], part, index) => {
+        const score = part.split(":")[1];
+        if (score === "HD+0") {
+            indexes.push(index);
         }
-    }
 
-    if (keyStrings.length == 0) {
-        keyStrings.push(keyString);
-    }
-
-    return keyStrings;
-}
-
-function splitKeyString(keyString: string, subString: string): string[] {
-    let keyStrings = [];
-
-    // assumes that the keystring has parts to replace
-    let parts = keyString.split("/");
-
-    const indices = parts.reduce((acc: number[], part, i) => {
-        // I have no idea why this needs to be inversed, but it does
-        if (!part.includes(subString)) { 
-            acc.push(i);
-        }
-        return acc;
+        return indexes;
     }, []);
-    
-    //console.log(indices); // Debug
 
-    for (let index in indices) {   
-        let newKeyString = [... parts];
-        newKeyString[index] = newKeyString[index].replace(subString, "0");
-        keyStrings.push(newKeyString.map(String).join("/"));
+    if (tiedHighestDamageIndexes.length <= 1) {
+        return [keyString];
     }
 
-    return keyStrings;
+    return tiedHighestDamageIndexes.map(highestDamageIndex => {
+        return parts.map((part, index) => {
+            if (tiedHighestDamageIndexes.includes(index) && index !== highestDamageIndex) {
+                return `${part.split(":")[0]}:0`;
+            }
+
+            return part;
+        }).join("/");
+    });
 }
 
 // Function to add or update a probability
@@ -660,7 +646,6 @@ function calculateHighestDamage(moves: any[]): KVP[] {
        let keyStrings = [];
        let keyString = "";
        i = 0;
-       let highestDamageSet = false;
        for (let key of keys) {
            if (keyString != "") {
                keyString += "/"
@@ -705,9 +690,8 @@ function calculateHighestDamage(moves: any[]): KVP[] {
            // if multiple moves kill, they are both highest damage 
            if (key === maximumKey && key >= p1CurrentHealth) {
                keyString += `${moveName}:HD+${moveBonus}`;
-           } else if (key === maximumKey && !highestDamageSet) {
+           } else if (key === maximumKey) {
                keyString += `${moveName}:HD+0`;
-               highestDamageSet = true;
            } else {
                keyString += `${moveName}:0`;
            }
@@ -720,7 +704,7 @@ function calculateHighestDamage(moves: any[]): KVP[] {
             probabilityOfChoice *= Number(probability);
         }
 
-        keyStrings = setKeyStrings(keyString, ["HD"]);
+        keyStrings = splitHighestDamageTies(keyString);
 
         for (const keyString of keyStrings) {
             // console.log(keyStrings); // Debug

--- a/calc/src/ai.ts
+++ b/calc/src/ai.ts
@@ -60,7 +60,7 @@ const powderMoves: string[] = [
     "Cotton Spore", "Magic Powder", "Poison Powder", "Powder", "Rage Powder", "Sleep Powder", "Spore", "Stun Spore"
 ];
 const statusApplyingMoves: string[] = [
-    "Grass Whistle", "Sleep Powder", "Lovely Kiss", "Spore"
+    "Grass Whistle", "Sleep Powder", "Lovely Kiss"
 ];
 const defrostingMoves: string[] = [
     "Burn Up", "Flame Wheel", "Flare Blitz", "Fusion Flare", "Pyro Ball", "Sacred Fire", "Scald", "Scorching Sands", "Steam Eruption"


### PR DESCRIPTION
Fixes incorrect AI move selection odds when two non-lethal moves tie in damage.

Previously, the calculator always prioritized the first move in the moveset during equal-damage scenarios, causing heavily skewed move percentages that did not match in-game behavior.

This update changes tie handling so that:

- Guaranteed higher-damage rolls are still prioritized correctly
- Exact damage ties are now split evenly between tied moves

Example case:

- Skiddo’s Tackle only strictly wins on its max roll (1/16)
- The remaining 15/16 rolls tie with Vine Whip
- Tied rolls are now treated as a 50/50 decision

Expected odds:

- Tackle ≈ 53%
- Vine Whip ≈ 47%

This now closely matches in-game AI behavior.

Fixes [#17](https://github.com/SylmarDev/syl-rnb-calc/issues/17)