### PR TITLE
fix(ai): make glare ineffective only against electric pokemon

### DIFF
--- a/calc/src/ai.ts
+++ b/calc/src/ai.ts
@@ -1670,16 +1670,15 @@ export function generateMoveDist(damageResults: any[], fastestSide: string, aiOp
             }
 
             // Thunder Wave, Stun Spore, Glare, Nuzzle
-            const nonElectricParalyzingMoves = ["Stun Spore", "Glare"];
-            const paralyzingMoves = ["Thunder Wave", "Stun Spore", ...nonElectricParalyzingMoves];
+            const paralyzingMoves = ["Thunder Wave", "Stun Spore", "Nuzzle", "Glare"];
             if (paralyzingMoves.includes(moveName)) {
                 const hexIndex = moves.findIndex(x => x.move.name === "Hex"); // hehe inHEX more like
                 var paraIncentive = aiSlowerButFasterAfterPara || hexIndex != -1 || playerCharmedOrConfused;
 
                 if (playerHasStatusCond || 
-                    (move.type == "Electric" && (playerTypes.includes("Ground") || playerTypes.includes("Electric"))) ||
+                    (move.type == "Electric" && (playerTypes.includes("Ground"))) ||
                     (playerAbility == "Limber") ||
-                    (paralyzingMoves.includes(moveName) && playerTypes.includes("Electric")))
+                    (playerTypes.includes("Electric")))
                 {
                     moveStringsToAdd.push({
                         move: moveName,

--- a/calc/src/ai.ts
+++ b/calc/src/ai.ts
@@ -1,12 +1,12 @@
-import { Result } from './result';
-import { Move } from './move';
-import { Generations, Pokemon } from '.';
-import { Field } from './field';
-import { MoveName } from './data/interface';
-import { getMoveEffectiveness } from './mechanics/util';
-import { calculateSMSSSV } from './mechanics/gen789';
+import { Generations, Pokemon } from '.'
+import { MoveName } from './data/interface'
+import { Field } from './field'
+import { calculateSMSSSV } from './mechanics/gen789'
+import { getMoveEffectiveness } from './mechanics/util'
+import { Move } from './move'
+import { Result } from './result'
 
-import * as I from './data/interface';
+import * as I from './data/interface'
 
 // interfaces
 interface KVP {
@@ -1670,14 +1670,16 @@ export function generateMoveDist(damageResults: any[], fastestSide: string, aiOp
             }
 
             // Thunder Wave, Stun Spore, Glare, Nuzzle
-            if (moveName == "Thunder Wave" || moveName == "Stun Spore" || moveName == "Nuzzle" || moveName == "Glare") {
+            const nonElectricParalyzingMoves = ["Stun Spore", "Glare"];
+            const paralyzingMoves = ["Thunder Wave", "Stun Spore", ...nonElectricParalyzingMoves];
+            if (paralyzingMoves.includes(moveName)) {
                 const hexIndex = moves.findIndex(x => x.move.name === "Hex"); // hehe inHEX more like
                 var paraIncentive = aiSlowerButFasterAfterPara || hexIndex != -1 || playerCharmedOrConfused;
 
                 if (playerHasStatusCond || 
                     (move.type == "Electric" && (playerTypes.includes("Ground") || playerTypes.includes("Electric"))) ||
                     (playerAbility == "Limber") ||
-                    (moveName == "Glare" || moveName == "Stun Spore" && playerTypes.includes("Electric")))  // glare needs its own cause its a normal type move
+                    (paralyzingMoves.includes(moveName) && playerTypes.includes("Electric")))
                 {
                     moveStringsToAdd.push({
                         move: moveName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2603,12 +2603,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "peer": true
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2870,18 +2864,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.48.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz",
@@ -2993,18 +2975,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.48.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.0.tgz",
@@ -3051,18 +3021,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -6293,18 +6251,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7619,12 +7565,16 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "devOptional": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -8032,18 +7982,6 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -8436,7 +8374,7 @@
         "@babel/generator": "^7.20.7",
         "@babel/helper-compilation-targets": "^7.20.7",
         "@babel/helper-module-transforms": "^7.20.11",
-        "@babel/helpers": "^7.26.10",
+        "@babel/helpers": ">=7.26.10",
         "@babel/parser": "^7.20.7",
         "@babel/template": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -8444,7 +8382,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "semver": ">=7.5.2"
       }
     },
     "@babel/generator": {
@@ -8501,7 +8439,7 @@
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "semver": ">=7.5.2"
       }
     },
     "@babel/helper-create-class-features-plugin": {
@@ -8541,7 +8479,7 @@
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
-        "semver": "^6.1.2"
+        "semver": ">=7.5.2"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -8608,7 +8546,7 @@
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.10",
+        "@babel/traverse": ">=7.23.2",
         "@babel/types": "^7.20.7"
       }
     },
@@ -8649,7 +8587,7 @@
         "@babel/helper-member-expression-to-functions": "^7.20.7",
         "@babel/helper-optimise-call-expression": "^7.18.6",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.7",
+        "@babel/traverse": ">=7.23.2",
         "@babel/types": "^7.20.7"
       }
     },
@@ -8706,7 +8644,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.19.0",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.5",
+        "@babel/traverse": ">=7.23.2",
         "@babel/types": "^7.20.5"
       }
     },
@@ -9485,7 +9423,7 @@
         "babel-plugin-polyfill-corejs3": "^0.6.0",
         "babel-plugin-polyfill-regenerator": "^0.4.1",
         "core-js-compat": "^3.25.1",
-        "semver": "^6.3.0"
+        "semver": ">=7.5.2"
       }
     },
     "@babel/preset-modules": {
@@ -9778,7 +9716,7 @@
         "jest-util": "^29.3.1",
         "jest-validate": "^29.3.1",
         "jest-watcher": "^29.3.1",
-        "micromatch": "^4.0.4",
+        "micromatch": ">=4.0.8",
         "pretty-format": "^29.3.1",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
@@ -10036,7 +9974,7 @@
         "jest-haste-map": "^29.3.1",
         "jest-regex-util": "^29.2.0",
         "jest-util": "^29.3.1",
-        "micromatch": "^4.0.4",
+        "micromatch": ">=4.0.8",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
         "write-file-atomic": "^4.0.1"
@@ -10224,12 +10162,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "peer": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -10469,16 +10401,8 @@
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.7",
+        "semver": ">=7.5.2",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-          "dev": true
-        }
       }
     },
     "@typescript-eslint/parser": {
@@ -10532,16 +10456,8 @@
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
+        "semver": ">=7.5.2",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-          "dev": true
-        }
       }
     },
     "@typescript-eslint/utils": {
@@ -10557,7 +10473,7 @@
         "@typescript-eslint/typescript-estree": "5.48.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
-        "semver": "^7.3.7"
+        "semver": ">=7.5.2"
       },
       "dependencies": {
         "eslint-scope": {
@@ -10574,12 +10490,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
           "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
           "dev": true
         }
       }
@@ -10779,7 +10689,7 @@
       "requires": {
         "@babel/compat-data": "^7.17.7",
         "@babel/helper-define-polyfill-provider": "^0.3.3",
-        "semver": "^6.1.1"
+        "semver": ">=7.5.2"
       }
     },
     "babel-plugin-polyfill-corejs3": {
@@ -10971,21 +10881,6 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
-    },
-    "chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "peer": true,
-      "requires": {
-        "@kurkle/color": "^0.3.0"
-      }
-    },
-    "chartjs-plugin-annotation": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-3.1.0.tgz",
-      "integrity": "sha512-EkAed6/ycXD/7n0ShrlT1T2Hm3acnbFhgkIEJLa0X+M6S16x0zwj1Fv4suv/2bwayCT3jGPdAtI9uLcAMToaQQ==",
-      "requires": {}
     },
     "ci-info": {
       "version": "3.7.1",
@@ -11251,7 +11146,7 @@
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": ">=7.0.5",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
@@ -11453,7 +11348,7 @@
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": ">=7.0.5",
         "get-stream": "^6.0.0",
         "human-signals": "^2.1.0",
         "is-stream": "^2.0.0",
@@ -11555,7 +11450,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": ">=4.0.8"
       },
       "dependencies": {
         "glob-parent": {
@@ -12016,7 +11911,7 @@
         "@babel/parser": "^7.14.7",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
+        "semver": ">=7.5.2"
       }
     },
     "istanbul-lib-report": {
@@ -12262,7 +12157,7 @@
         "jest-runner": "^29.3.1",
         "jest-util": "^29.3.1",
         "jest-validate": "^29.3.1",
-        "micromatch": "^4.0.4",
+        "micromatch": ">=4.0.8",
         "parse-json": "^5.2.0",
         "pretty-format": "^29.3.1",
         "slash": "^3.0.0",
@@ -12492,7 +12387,7 @@
         "jest-regex-util": "^29.2.0",
         "jest-util": "^29.3.1",
         "jest-worker": "^29.3.1",
-        "micromatch": "^4.0.4",
+        "micromatch": ">=4.0.8",
         "walker": "^1.0.8"
       }
     },
@@ -12580,7 +12475,7 @@
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
+        "micromatch": ">=4.0.8",
         "pretty-format": "^29.3.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
@@ -12920,7 +12815,7 @@
         "@babel/generator": "^7.7.2",
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/traverse": "^7.7.2",
+        "@babel/traverse": ">=7.23.2",
         "@babel/types": "^7.3.3",
         "@jest/expect-utils": "^29.3.1",
         "@jest/transform": "^29.3.1",
@@ -12939,7 +12834,7 @@
         "jest-util": "^29.3.1",
         "natural-compare": "^1.4.0",
         "pretty-format": "^29.3.1",
-        "semver": "^7.3.5"
+        "semver": ">=7.5.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12980,12 +12875,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
           "dev": true
         },
         "supports-color": {
@@ -13352,7 +13241,7 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "requires": {
-        "semver": "^6.0.0"
+        "semver": ">=7.5.2"
       }
     },
     "make-error": {
@@ -13406,7 +13295,7 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.3",
+        "braces": ">=3.0.3",
         "picomatch": "^2.3.1"
       }
     },
@@ -13443,7 +13332,7 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.12"
+        "brace-expansion": ">=1.1.12"
       }
     },
     "ms": {
@@ -13541,7 +13430,7 @@
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "word-wrap": ">=1.2.4"
       }
     },
     "p-limit": {
@@ -13937,9 +13826,9 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "devOptional": true
     },
     "send": {
@@ -14238,16 +14127,8 @@
         "json5": "^2.2.1",
         "lodash.memoize": "4.x",
         "make-error": "1.x",
-        "semver": "7.x",
+        "semver": ">=7.5.2",
         "yargs-parser": "^21.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-          "dev": true
-        }
       }
     },
     "tslib": {


### PR DESCRIPTION
`Glare` was programmed to always be ineffective, so it had a 0% percentage to be clicked in the calculator. The reason is because of the order of operations in:

```
(moveName == "Glare" || moveName == "Stun Spore" && playerTypes.includes("Electric")))
```

There is the comment `// glare needs its own cause its a normal type move`, but I'm not sure what it was referencing to exactly

Tested against Oddish (non ground/electric), Donphan (ground), Electrode (electric) in the calculator manually