### PR TITLE
feat(color-coding): add color coding support on chosen pokemon icon when turned on

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -1849,8 +1849,21 @@ function colorCodeUpdate(){
 		else if (ohkoCheck){
 			pMons[i].className = `trainer-pok left-side mon-dmg-${idColor.code}`;
 		}
-		
-		
+
+
+	}
+	var p1monEl = document.getElementById("p1mon");
+	if (p1monEl && p1monEl.src) {
+		try {
+			var p1Color = calculationsColors($("#p1"), p2);
+			if (speCheck && ohkoCheck){
+				p1monEl.className = `mon-speed-${p1Color.speed} mon-dmg-${p1Color.code}`;
+			} else if (speCheck){
+				p1monEl.className = `mon-speed-${p1Color.speed}`;
+			} else if (ohkoCheck){
+				p1monEl.className = `mon-dmg-${p1Color.code}`;
+			}
+		} catch(e) {}
 	}
 }
 function showColorCodes(){
@@ -1867,6 +1880,7 @@ function hideColorCodes(){
 	for (let i = 0; i < pMons.length; i++) {
 		pMons[i].className = "trainer-pok left-side";
 	}
+	document.getElementById("p1mon").className = "";
 	document.getElementById("cc-auto-refr").checked = false;
 	HideShowCCSettings();
 }
@@ -1954,6 +1968,14 @@ function SpeedBorderSetsChange(ev){
 			monImg.classList.add("mon-speed-none")
 		}
 	}
+	var p1monEl = document.getElementById("p1mon");
+	if (p1monEl && p1monEl.className) {
+		if (ev.target.checked) {
+			p1monEl.classList.remove("mon-speed-none");
+		} else {
+			p1monEl.classList.add("mon-speed-none");
+		}
+	}
 }
 
 function ColorCodeSetsChange(ev){
@@ -1965,6 +1987,14 @@ function ColorCodeSetsChange(ev){
 	}else{
 		for (let monImg of monImgs){
 			monImg.classList.add("mon-dmg-none")
+		}
+	}
+	var p1monEl = document.getElementById("p1mon");
+	if (p1monEl && p1monEl.className) {
+		if (ev.target.checked) {
+			p1monEl.classList.remove("mon-dmg-none");
+		} else {
+			p1monEl.classList.add("mon-dmg-none");
 		}
 	}
 }


### PR DESCRIPTION
I find that when focusing on the damage portion of the calc, I can lose track of what the pokemon speed are because the stats themselves are out of my vision

So I thought that adding color coding support for the chosen pokemon icon itself makes sense as a way to notify the users of the speed stat since that is already an existing functionality

Demo recording:

https://github.com/user-attachments/assets/7ae7ebf8-df97-42ce-9b47-e0620aec6731

