### PR TITLE
feat(export): add export all functionality for opposing team + speed stat on export all

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -209,7 +209,8 @@ input.select2-input {
 }
 
 /* Export All */
-#massExport-overlay {
+#massExport-overlay,
+#massExportR-overlay {
     display: none;
     position: fixed;
     top: 0; left: 0;
@@ -218,7 +219,8 @@ input.select2-input {
     z-index: 1000;
 }
 
-#massExport-popup {
+#massExport-popup,
+#massExportR-popup {
     position: relative;
     top: 50%; left: 50%;
     transform: translate(-50%, -50%);
@@ -229,19 +231,22 @@ input.select2-input {
     box-shadow: 0 4px 12px rgba(255, 255, 255, 0.2);
 }
 
-#massExport-header {
+#massExport-header,
+#massExportR-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 10px;
 }
 
-#massExport-popup h2 {
+#massExport-popup h2,
+#massExportR-popup h2 {
     color: #fff;
     margin: 0;
 }
 
-#massExport-copy {
+#massExport-copy,
+#massExportR-copy {
     gap: 6px;
     padding: 6px 12px;
     background: #2a2a2a;
@@ -255,26 +260,31 @@ input.select2-input {
     width: 130px;
 }
 
-#massExport-copy svg {
+#massExport-copy svg,
+#massExportR-copy svg {
     margin-top: 1px;
 }
 
-#massExport-copy:hover {
+#massExport-copy:hover,
+#massExportR-copy:hover {
     background: #3a3a3a;
     border-color: #777;
 }
 
-#massExport-copy:active {
+#massExport-copy:active,
+#massExportR-copy:active {
     background: #1a1a1a;
 }
 
-#massExport-copy svg {
+#massExport-copy svg,
+#massExportR-copy svg {
     width: 16px;
     height: 16px;
     flex-shrink: 0;
 }
 
-#massExport-close {
+#massExport-close,
+#massExportR-close {
     position: absolute;
     top: 20px;
     right: 20px;
@@ -284,11 +294,13 @@ input.select2-input {
     z-index: 1;
 }
 
-#massExport-close:hover {
+#massExport-close:hover,
+#massExportR-close:hover {
     color: #333;
 }
 
-#massExport-div {
+#massExport-div,
+#massExportR-div {
     margin-top: 7px;
     font-family: Arial, sans-serif;
     font-size: 14px;
@@ -298,7 +310,8 @@ input.select2-input {
     padding-right: 15px;
 }
 
-#massExport-text {
+#massExport-text,
+#massExportR-text {
     white-space: pre-wrap;
     word-wrap: break-word;
     margin: 0;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -994,7 +994,8 @@ table.field {
 }
 
 /* Export All */
-#massExport-overlay {
+#massExport-overlay,
+#massExportR-overlay {
     display: none;
     position: fixed;
     top: 0; left: 0;
@@ -1003,7 +1004,8 @@ table.field {
     z-index: 1000;
 }
 
-#massExport-popup {
+#massExport-popup,
+#massExportR-popup {
     position: relative;
     top: 50%; left: 50%;
     transform: translate(-50%, -50%);
@@ -1014,19 +1016,22 @@ table.field {
     box-shadow: 0 4px 12px rgba(255, 255, 255, 0.2);
 }
 
-#massExport-header {
+#massExport-header,
+#massExportR-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 10px;
 }
 
-#massExport-popup h2 {
+#massExport-popup h2,
+#massExportR-popup h2 {
     color: #fff;
     margin: 0;
 }
 
-#massExport-copy {
+#massExport-copy,
+#massExportR-copy {
     gap: 6px;
     padding: 6px 12px;
     background: #2a2a2a;
@@ -1040,26 +1045,31 @@ table.field {
     width: 130px;
 }
 
-#massExport-copy svg {
+#massExport-copy svg,
+#massExportR-copy svg {
     margin-top: 1px;
 }
 
-#massExport-copy:hover {
+#massExport-copy:hover,
+#massExportR-copy:hover {
     background: #3a3a3a;
     border-color: #777;
 }
 
-#massExport-copy:active {
+#massExport-copy:active,
+#massExportR-copy:active {
     background: #1a1a1a;
 }
 
-#massExport-copy svg {
+#massExport-copy svg,
+#massExportR-copy svg {
     width: 16px;
     height: 16px;
     flex-shrink: 0;
 }
 
-#massExport-close {
+#massExport-close,
+#massExportR-close {
     position: absolute;
     top: 20px;
     right: 20px;
@@ -1069,11 +1079,13 @@ table.field {
     z-index: 1;
 }
 
-#massExport-close:hover {
+#massExport-close:hover,
+#massExportR-close:hover {
     color: #333;
 }
 
-#massExport-div {
+#massExport-div,
+#massExportR-div {
     margin-top: 7px;
     font-family: Arial, sans-serif;
     font-size: 14px;
@@ -1083,7 +1095,8 @@ table.field {
     padding-right: 15px;
 }
 
-#massExport-text {
+#massExport-text,
+#massExportR-text {
     white-space: pre-wrap;
     word-wrap: break-word;
     margin: 0;

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -70,6 +70,26 @@
     </div>
   </div>
 
+<div id="massExportR-overlay">
+    <div id="massExportR-popup">
+      <span id="massExportR-close">&times;</span>
+      <div id="massExportR-header">
+        <h2>Export All (Opposing)</h2>
+        <button id="massExportR-copy" class="btn-copy" title="Copy to clipboard">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+            <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z"/>
+            <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0z"/>
+          </svg>
+          Copy
+        </button>
+      </div>
+      <div id="massExportR-div">
+        <p id="massExportR-text">
+        </p>
+      </div>
+    </div>
+  </div>
+
 <div class="wrapper">
     <div aria-label="Settings" role="region">
         <span class="title-text">Pok&eacute;mon Damage Calculator</span>
@@ -1229,6 +1249,7 @@
                             </div></td>
                             <td><div class="right" title="Export the rightmost Pok&eacute;mon set">
                                 <button id="exportR">Export</button>
+                                <button id="massExportR">Export All</button>
                             </div></td>
                         </tr>
                     </tbody>

--- a/src/js/moveset_import.js
+++ b/src/js/moveset_import.js
@@ -90,6 +90,16 @@ function ExportPokemon(pokeInfo) {
 	$("textarea.import-team-text").val(finalText);
 }
 
+function calcSpeedStat(monName, set) {
+	/* global pokedex, gen, calc */
+	var mon = pokedex[monName];
+	if (!mon) return undefined;
+	var base = mon.bs.sp;
+	var iv = (set.ivs && set.ivs.sp !== undefined) ? set.ivs.sp : 31;
+	var ev = (set.evs && set.evs.sp !== undefined) ? set.evs.sp : 0;
+	return calc.calcStat(gen, 'spe', base, iv, ev, set.level ?? 100, set.nature ?? 'Serious');
+}
+
 function parseSetsFromCustomSets(customSets) {
 	var finalText = "";
 
@@ -98,14 +108,15 @@ function parseSetsFromCustomSets(customSets) {
 			var poke = customSets[monName][setName];
 			var item = poke.hasOwnProperty('item') ? ` @ ${poke.item}` : '';
 			var ivs = poke.hasOwnProperty('ivs') ? formatIVs(poke.ivs) : '';
-			
 			var ivLine = ivs !== "" ? `IVs: ${ivs}\n` : '';
+			var speed = calcSpeedStat(monName, poke);
+			var speedLine = speed !== undefined ? `Speed: ${speed}\n` : '';
 
-			var text = 
+			var text =
 `${monName}${item}
 Level: ${poke.level ?? 100}
 ${poke.nature ?? 'Serious'} Nature
-Ability: ${poke.ability}\n${ivLine !== "" ? `${ivLine}` : ''}`;
+Ability: ${poke.ability}\n${ivLine}${speedLine}`;
 
 			for (var move of poke.moves) {
 				text += `- ${move}\n`;
@@ -140,6 +151,69 @@ $("#massExport").click(function () {
 // Copy button functionality
 $("#massExport-copy").click(function () {
 	copyMassExportToClipboard();
+});
+
+function parseSetsFromTrainerTeam(trainerPoks) {
+	var finalText = "";
+
+	for (var i = 0; i < trainerPoks.length; i++) {
+		var entry = trainerPoks[i];
+		var afterBracket = entry.split("]")[1];
+		if (!afterBracket) continue;
+		var monName = afterBracket.split(" (")[0];
+		var trainerName = entry.split("(")[1].split(")")[0];
+
+		if (!setdex[monName] || !setdex[monName][trainerName]) continue;
+
+		var set = setdex[monName][trainerName];
+		var item = set.item ? ` @ ${set.item}` : '';
+		var ivs = set.ivs ? formatIVs(set.ivs) : '';
+		var ivLine = ivs !== "" ? `IVs: ${ivs}\n` : '';
+		var speed = calcSpeedStat(monName, set);
+		var speedLine = speed !== undefined ? `Speed: ${speed}\n` : '';
+
+		var text =
+`${monName}${item}
+Level: ${set.level ?? 100}
+${set.nature ?? 'Serious'} Nature
+Ability: ${set.ability}\n${ivLine}${speedLine}`;
+
+		for (var move of set.moves) {
+			text += `- ${move}\n`;
+		}
+
+		finalText += `${text}\n`;
+	}
+
+	return finalText;
+}
+
+$("#massExportR").click(function () {
+	/* global CURRENT_TRAINER_POKS */
+	if (typeof CURRENT_TRAINER_POKS === 'undefined' || CURRENT_TRAINER_POKS.length === 0) {
+		alert("No opposing trainer loaded.");
+		return;
+	}
+	var exportAll = parseSetsFromTrainerTeam(CURRENT_TRAINER_POKS);
+	$("#massExportR-text").text(exportAll);
+	showMassExportR();
+});
+
+$("#massExportR-copy").click(function () {
+	var text = $("#massExportR-text").text();
+	if (text) {
+		navigator.clipboard.writeText(text).then(function () {
+			var $btn = $("#massExportR-copy");
+			var originalText = $btn.html();
+			$btn.html('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/></svg> Copied!');
+			setTimeout(function () {
+				$btn.html(originalText);
+			}, 2000);
+		}).catch(function (err) {
+			console.error('Failed to copy text: ', err);
+			alert('Failed to copy to clipboard');
+		});
+	}
 });
 
 function copyMassExportToClipboard() {

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -2122,6 +2122,10 @@ function showMassExport() {
 	$('#massExport-overlay').fadeIn(200);
 }
 
+function showMassExportR() {
+	$('#massExportR-overlay').fadeIn(200);
+}
+
 $(document).ready(function () {
 	var params = new URLSearchParams(window.location.search);
 	var g = GENERATION[params.get('gen')] || 8;
@@ -2220,6 +2224,12 @@ $(document).ready(function () {
     $('#massExport-close, #massExport-overlay').on('click', function (e) {
       if (e.target.id === 'massExport-close' || e.target.id === 'massExport-overlay') {
         $('#massExport-overlay').fadeOut(200);
+      }
+    });
+
+    $('#massExportR-close, #massExportR-overlay').on('click', function (e) {
+      if (e.target.id === 'massExportR-close' || e.target.id === 'massExportR-overlay') {
+        $('#massExportR-overlay').fadeOut(200);
       }
     });
 });


### PR DESCRIPTION
Having a global view of the opposing team's pokemons are quite useful to keep track of the user's team. There is already an `Export` functionality for the opposing team, but not an `Export All`.

In addition to adding that button, also include the pokemon's speed, again for a global view and ease of comparison