### PR TITLE
feat(calc): add base of mega form pokemon in the opposing team's roster

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -1772,6 +1772,7 @@ $(document).on('click', '.right-side', function () {
 			|| (basePokemon && basePokemon.ab)
 			|| "";
 		pokeObj.find(".ability").val(baseAbility).keyup();
+		pokeObj.find("select.forme").val(baseName);
 	}
 })
 

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -1766,7 +1766,9 @@ $(document).on('click', '.right-side', function () {
 			calcStats(pokeObj);
 		}
 		var trainerName = set.substring(set.indexOf("(") + 1, set.lastIndexOf(")"));
-		var baseAbility = (MEGA_BASE_ABILITIES[trainerName] && MEGA_BASE_ABILITIES[trainerName][baseName])
+		if (trainerName.includes("Trainer Rival")) { trainerName = "Pokemon Trainer May"; }
+		var mbaKey = Object.keys(MEGA_BASE_ABILITIES).find(k => trainerName.includes(k)) || trainerName;
+		var baseAbility = (MEGA_BASE_ABILITIES[mbaKey] && MEGA_BASE_ABILITIES[mbaKey][baseName])
 			|| (basePokemon && basePokemon.ab)
 			|| "";
 		pokeObj.find(".ability").val(baseAbility).keyup();

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -480,6 +480,11 @@ $(".set-selector").change(function () {
 			}
 			
 			// this ruined my day
+			if (pok_name.includes("-Mega")) {
+				var base_name = pok_name.split("-Mega")[0]
+				var mega_data_id = CURRENT_TRAINER_POKS[i].split("]")[1]
+				trpok_html += `<img class="trainer-pok right-side" src="https://raw.githubusercontent.com/May8th1995/sprites/master/${base_name}.png" data-id="${mega_data_id}" data-base-name="${base_name}" title="${next_poks[i]}, ${next_poks[i]} BP">`
+			}
 			var pok = `<img class="trainer-pok right-side" src="https://raw.githubusercontent.com/May8th1995/sprites/master/${pok_name}.png" data-id="${CURRENT_TRAINER_POKS[i].split("]")[1]}" title="${next_poks[i]}, ${next_poks[i]} BP">`
 			trpok_html += pok
 		}
@@ -1739,12 +1744,33 @@ function setDisclaimVisibility(moveNames) {
 
 $(document).on('click', '.right-side', function () {
 	var set = $(this).attr('data-id');
-	topPokemonIcon(set, $("#p2mon")[0])
+	var baseName = $(this).attr('data-base-name');
 	$('.opposing').val(set);
 	$('input.opposing').prop('title', $(this).prop('title').split("]")[0].slice(1));
 	$('.opposing').change();
-	$('.opposing .select2-chosen').text(set);
+	topPokemonIcon(baseName ? baseName + " (" + set.substring(set.indexOf("(") + 1) : set, $("#p2mon")[0])
+	var displayName = baseName ? baseName + " (" + set.substring(set.indexOf("(") + 1) : set;
+	$('.opposing .select2-chosen').text(displayName);
 	setAiOptionAndDisclaimVisibility('p2');
+	if (baseName) {
+		var basePokemon = pokedex[baseName];
+		var pokeObj = $('.opposing').closest(".poke-info");
+		if (basePokemon) {
+			pokeObj.find(".type1").val(basePokemon.types[0]);
+			pokeObj.find(".type2").val(basePokemon.types[1]);
+			pokeObj.find(".hp .base").val(basePokemon.bs.hp);
+			for (var si = 0; si < LEGACY_STATS[gen].length; si++) {
+				pokeObj.find("." + LEGACY_STATS[gen][si] + " .base").val(basePokemon.bs[LEGACY_STATS[gen][si]]);
+			}
+			calcHP(pokeObj);
+			calcStats(pokeObj);
+		}
+		var trainerName = set.substring(set.indexOf("(") + 1, set.lastIndexOf(")"));
+		var baseAbility = (MEGA_BASE_ABILITIES[trainerName] && MEGA_BASE_ABILITIES[trainerName][baseName])
+			|| (basePokemon && basePokemon.ab)
+			|| "";
+		pokeObj.find(".ability").val(baseAbility).keyup();
+	}
 })
 
 $(document).on('click', '.left-side', function () {


### PR DESCRIPTION
Added functionality similar to the null calculator that includes the base form of the mega pokemons to the left of the mega pokemon :)

<img width="500" height="747" alt="Screenshot 2026-05-19 at 6 29 39 PM" src="https://github.com/user-attachments/assets/6b32169c-3106-4039-9fd2-bf193552167f" />
<img width="448" height="753" alt="Screenshot 2026-05-19 at 6 24 09 PM" src="https://github.com/user-attachments/assets/f01898b7-8074-4600-bf4f-6841bf6bd3d0" />

