### PR TITLE
Include Spore in statusApplyingMoves

### DIFF
--- a/calc/src/ai.ts
+++ b/calc/src/ai.ts
@@ -60,7 +60,7 @@ const powderMoves: string[] = [
     "Cotton Spore", "Magic Powder", "Poison Powder", "Powder", "Rage Powder", "Sleep Powder", "Spore", "Stun Spore"
 ];
 const statusApplyingMoves: string[] = [
-    "Grass Whistle", "Sleep Powder", "Lovely Kiss"
+    "Grass Whistle", "Sleep Powder", "Lovely Kiss", "Spore"
 ];
 const defrostingMoves: string[] = [
     "Burn Up", "Flame Wheel", "Flare Blitz", "Fusion Flare", "Pyro Ball", "Sacred Fire", "Scald", "Scorching Sands", "Steam Eruption"


### PR DESCRIPTION
Added Spore to the status-move filter in `ai.ts`, preventing it from receiving the generic +6 status score when the target is already affected by another status condition. This aligns Spore's AI scoring with other status-inflicting moves.