### PR TITLE
Show move critical-hit rate labels

### DIFF
--- a/calc/src/ai.ts
+++ b/calc/src/ai.ts
@@ -64,7 +64,7 @@ const statusApplyingMoves: string[] = [
 ];
 const defrostingMoves: string[] = [
     "Burn Up", "Flame Wheel", "Flare Blitz", "Fusion Flare", "Pyro Ball", "Sacred Fire", "Scald", "Scorching Sands", "Steam Eruption"
-]
+];
 
 // move functions
 function isNamed(moveName: string, ...names: string[]) {

--- a/calc/src/ai.ts
+++ b/calc/src/ai.ts
@@ -222,7 +222,7 @@ function getAIDeadAfterShellSmash(res: any[], playerMaxDamage: number) {
     return playerMaxDamageAfterSS >= aiCurrentHp;
 }
 
-function getMoveIsStatus(moveName: string, moveBp: number) {
+export function getMoveIsStatus(moveName: string, moveBp: number) {
     return moveBp <= 0 &&
         !isNamed(moveName, ...zeroBPButNotStatus)
 }

--- a/calc/src/calc.ts
+++ b/calc/src/calc.ts
@@ -4,7 +4,7 @@ import {Move} from './move';
 import {Pokemon} from './pokemon';
 import {Result} from './result';
 
-import { generateMoveDist } from "./ai";
+import { generateMoveDist, getMoveIsStatus } from "./ai";
 
 import {calculateRBYGSC} from './mechanics/gen12';
 import {calculateADV} from './mechanics/gen3';

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -669,7 +669,7 @@ select.toxic-counter {
 }
 .poke-info .crit-btn {
     font-size: 0.8em;
-    width: 5em;
+    width: 2.5em;
     height: 1em;
     padding: 3px 3px;
     margin: 0px 1px;
@@ -685,6 +685,16 @@ select.toxic-counter {
 
 .small-crit-btn[id*="TopL"] {
     margin-left: 0.8em;
+}
+
+.crit-rate {
+    display: inline-block;
+    min-width: 2.7em;
+    font-size: 0.75em;
+    color: inherit;
+    opacity: 0.75;
+    vertical-align: middle;
+    margin-left: 2px;
 }
 
 /* field info */

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -669,10 +669,14 @@ select.toxic-counter {
 }
 .poke-info .crit-btn {
     font-size: 0.8em;
-    width: 2.5em;
+    width: 5em;
     height: 1em;
     padding: 3px 3px;
     margin: 0px 1px;
+}
+
+body.show-crit-percentages .poke-info .crit-btn {
+    width: 2.5em;
 }
 
 .small-crit-btn {
@@ -688,12 +692,21 @@ select.toxic-counter {
 }
 
 .crit-rate {
-    display: inline-block;
-    min-width: 2.7em;
-    font-size: 0.75em;
+    display: inline;
+    white-space: nowrap;
+    font-size: 0.85em;
     color: inherit;
     vertical-align: middle;
-    margin-bottom: 4px;
+    margin-bottom: 3px;
+}
+
+.crit-rate-value,
+.crit-rate-sign {
+    display: inline;
+}
+
+.crit-rate-sign {
+    font-size: 0.7em;
 }
 
 /* field info */

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -692,9 +692,8 @@ select.toxic-counter {
     min-width: 2.7em;
     font-size: 0.75em;
     color: inherit;
-    opacity: 0.75;
     vertical-align: middle;
-    margin-left: 2px;
+    margin-bottom: 4px;
 }
 
 /* field info */

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -700,13 +700,17 @@ body.show-crit-percentages .poke-info .crit-btn {
     margin-bottom: 3px;
 }
 
-.crit-rate-value,
-.crit-rate-sign {
-    display: inline;
+.crit-rate-value {
+    display: inline-block;
+    min-width: 4ch;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
 }
 
 .crit-rate-sign {
+    display: inline;
     font-size: 0.7em;
+    width: 1em !important;
 }
 
 /* field info */

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -712,6 +712,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critL1" />
                     <label class="btn crit-btn" for="critL1" title="Force this attack to be a critical hit?">Crit</label>
+                    <span class="crit-rate" id="critRateL1"></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -744,6 +745,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critL2" />
                     <label class="btn crit-btn" for="critL2" title="Force this attack to be a critical hit?">Crit</label>
+                    <span class="crit-rate" id="critRateL2"></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -776,6 +778,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critL3" />
                     <label class="btn crit-btn" for="critL3" title="Force this attack to be a critical hit?">Crit</label>
+                    <span class="crit-rate" id="critRateL3"></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -808,6 +811,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critL4" />
                     <label class="btn crit-btn" for="critL4" title="Force this attack to be a critical hit?">Crit</label>
+                    <span class="crit-rate" id="critRateL4"></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -1668,6 +1672,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critR1" />
                     <label class="btn crit-btn" for="critR1" title="Force this attack to be a critical hit?">Crit</label>
+                    <span class="crit-rate" id="critRateR1"></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -1700,6 +1705,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critR2" />
                     <label class="btn crit-btn" for="critR2" title="Force this attack to be a critical hit?">Crit</label>
+                    <span class="crit-rate" id="critRateR2"></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -1732,6 +1738,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critR3" />
                     <label class="btn crit-btn" for="critR3" title="Force this attack to be a critical hit?">Crit</label>
+                    <span class="crit-rate" id="critRateR3"></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -1764,6 +1771,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critR4" />
                     <label class="btn crit-btn" for="critR4" title="Force this attack to be a critical hit?">Crit</label>
+                    <span class="crit-rate" id="critRateR4"></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -1924,6 +1924,10 @@
             <label class="unselectable" for="teamsOnTop">Box On Top</label>
             <input class="" type="checkbox" name="teamsOnTop" id="teamsOnTop" aria-describedby="aiOption" />
         </li>
+        <li>
+            <label class="unselectable" for="showCritPercentages">Show Crit Percentages</label>
+            <input class="" type="checkbox" name="showCritPercentages" id="showCritPercentages" aria-describedby="aiOption" checked />
+        </li>
         <li><a href="https://twitch.tv/princesssylmar" class="links-lighten" target="_blank">My twitch :3</a></li>
         <li><p>Shoutouts to the original <a href="https://github.com/smogon/damage-calc/contributors" class="links-lighten" target="_blank">Smogon Contributors</a></p></li>
     </ul>    

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -712,7 +712,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critL1" />
                     <label class="btn crit-btn" for="critL1" title="Force this attack to be a critical hit?">Crit</label>
-                    <span class="crit-rate" id="critRateL1"></span>
+                    <span class="crit-rate" id="critRateL1"><span class="crit-rate-value"></span><span class="crit-rate-sign">%</span></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -745,7 +745,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critL2" />
                     <label class="btn crit-btn" for="critL2" title="Force this attack to be a critical hit?">Crit</label>
-                    <span class="crit-rate" id="critRateL2"></span>
+                    <span class="crit-rate" id="critRateL2"><span class="crit-rate-value"></span><span class="crit-rate-sign">%</span></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -778,7 +778,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critL3" />
                     <label class="btn crit-btn" for="critL3" title="Force this attack to be a critical hit?">Crit</label>
-                    <span class="crit-rate" id="critRateL3"></span>
+                    <span class="crit-rate" id="critRateL3"><span class="crit-rate-value"></span><span class="crit-rate-sign">%</span></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -811,7 +811,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critL4" />
                     <label class="btn crit-btn" for="critL4" title="Force this attack to be a critical hit?">Crit</label>
-                    <span class="crit-rate" id="critRateL4"></span>
+                    <span class="crit-rate" id="critRateL4"><span class="crit-rate-value"></span><span class="crit-rate-sign">%</span></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -1672,7 +1672,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critR1" />
                     <label class="btn crit-btn" for="critR1" title="Force this attack to be a critical hit?">Crit</label>
-                    <span class="crit-rate" id="critRateR1"></span>
+                    <span class="crit-rate" id="critRateR1"><span class="crit-rate-value"></span><span class="crit-rate-sign">%</span></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -1705,7 +1705,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critR2" />
                     <label class="btn crit-btn" for="critR2" title="Force this attack to be a critical hit?">Crit</label>
-                    <span class="crit-rate" id="critRateR2"></span>
+                    <span class="crit-rate" id="critRateR2"><span class="crit-rate-value"></span><span class="crit-rate-sign">%</span></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -1738,7 +1738,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critR3" />
                     <label class="btn crit-btn" for="critR3" title="Force this attack to be a critical hit?">Crit</label>
-                    <span class="crit-rate" id="critRateR3"></span>
+                    <span class="crit-rate" id="critRateR3"><span class="crit-rate-value"></span><span class="crit-rate-sign">%</span></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>
@@ -1771,7 +1771,7 @@
                     </select>
                     <input aria-describedby="criticalHitInstruction" class="move-crit calc-trigger visually-hidden" type="checkbox" id="critR4" />
                     <label class="btn crit-btn" for="critR4" title="Force this attack to be a critical hit?">Crit</label>
-                    <span class="crit-rate" id="critRateR4"></span>
+                    <span class="crit-rate" id="critRateR4"><span class="crit-rate-value"></span><span class="crit-rate-sign">%</span></span>
                     <select class="move-hits calc-trigger hide">
                         <option value="2">2 hits</option>
                         <option value="3">3 hits</option>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -1892,6 +1892,7 @@
     <script type="text/javascript" src="./calc/result.js?"></script>
     <script type="text/javascript" src="./calc/adaptable.js?"></script>
     <script type="text/javascript" src="./calc/index.js?"></script>
+    <script type="text/javascript" src="./js/crit_rate.js?"></script>
     <script type="text/javascript" src="./js/shared_controls.js?"></script>
     <script type="text/javascript" src="./js/index_randoms_controls.js?"></script>
     <script type="text/javascript" src="./js/moveset_import.js?"></script>

--- a/src/js/crit_rate.js
+++ b/src/js/crit_rate.js
@@ -22,10 +22,12 @@ function strMatch(s, ...matches) {
 	return match;
 }
 
-function getCritRate(attacker, defender, aField, dField, moveIndex) {
+function getCritRate(attacker, defender, aField, dField, moveIndex, honorCritFlag = true) {
     console.log(attacker, defender, aField, dField, moveIndex);
 	if (strMatch(defender.ability, ...critBlockingAbilities) ||
 		(dField.isLuckyChant ?? false)) { return 0; }
+
+	if (attacker.moves[moveIndex].isCrit && honorCritFlag) { return 1; }
 
 	stages = [0.0625, 0.125, 0.5, 1];
 

--- a/src/js/crit_rate.js
+++ b/src/js/crit_rate.js
@@ -1,0 +1,51 @@
+var highCritRatioMoveNames = [
+	"Aeroblast", "Air Cutter", "Attack Order",
+	"Blaze Kick", "Crabhammer", "Cross Chop", "Cross Poison", "Drill Run",
+	"Karate Chop", "Leaf Blade", "Night Slash", "Poison Tail", "Psycho Cut",
+	"Razor Leaf", "Razor Wind", "Shadow Claw", "Sky Attack", "Slash",
+	"Spacial Rend", "Stone Edge"
+];
+
+var critBlockingAbilities = [
+	"Shell Armor", "Battle Armor", "Magma Armor"
+]
+
+var highCritRatioItems = [
+	"Razor Claw", "Scope Lens"
+]
+
+function strMatch(s, ...matches) {
+	var match = false;
+	matches.forEach(function(m) {
+		if (s == m) { match = true; }
+	});
+	return match;
+}
+
+function getCritRate(attacker, defender, aField, dField, moveIndex) {
+    console.log(attacker, defender, aField, dField, moveIndex);
+	if (strMatch(defender.ability, ...critBlockingAbilities) ||
+		(dField.isLuckyChant ?? false)) { return 0; }
+
+	stages = [0.0625, 0.125, 0.5, 1];
+
+	boosts = 0;
+
+	if (strMatch(attacker.moves[moveIndex].originalName, ...highCritRatioMoveNames)) {
+		boosts++;
+	}
+
+	if (strMatch(attacker.item, ...highCritRatioItems)) { boosts++; }
+	if (strMatch(attacker.ability, "Super Luck")) { boosts++; }
+	if (attacker.name.includes("fetch'd") && 
+		(attacker.item == "Leek" || attacker.item == "Stick")) { boosts += 2; }
+	if (attacker.name == "Chansey" && attacker.item == "Lucky Punch") { boosts += 2; }
+	if (aField.isFocusEnergy) { boosts += 2; }
+
+	boosts = Math.min(boosts, stages.length-1);
+	
+	// console.log(`returning ${stages[boosts]}`);
+	return stages[boosts];
+}
+
+window.getCritRate = getCritRate;

--- a/src/js/crit_rate.js
+++ b/src/js/crit_rate.js
@@ -22,27 +22,30 @@ function strMatch(s, ...matches) {
 	return match;
 }
 
+// TODO: one field probably works with some refactoring
 function getCritRate(attacker, defender, aField, dField, moveIndex, honorCritFlag = true) {
-    console.log(attacker, defender, aField, dField, moveIndex);
-	if (strMatch(defender.ability, ...critBlockingAbilities) ||
-		(dField.isLuckyChant ?? false)) { return 0; }
+	console.log(attacker, defender, aField, dField, moveIndex); // DEBUG
+	const move = attacker.moves[moveIndex];
+	const moveName = move.name;
+	const attackerNotInitialized = attacker.item === null || attacker.ability === null || attacker.name === null;
+	const critBlocking = strMatch(defender.ability, ...critBlockingAbilities) || (dField.isLuckyChant ?? false);
 
-	if (attacker.moves[moveIndex].isCrit && honorCritFlag) { return 1; }
+	if (attackerNotInitialized || critBlocking || calc.getMoveIsStatus(moveName, move.bp)) { return 0; }
+	if (move.isCrit && honorCritFlag) { return 1; }
 
 	stages = [0.0625, 0.125, 0.5, 1];
 
 	boosts = 0;
 
-	if (strMatch(attacker.moves[moveIndex].originalName, ...highCritRatioMoveNames)) {
+	if (strMatch(move.originalName, ...highCritRatioMoveNames)) {
 		boosts++;
 	}
 
 	if (strMatch(attacker.item, ...highCritRatioItems)) { boosts++; }
 	if (strMatch(attacker.ability, "Super Luck")) { boosts++; }
-	if (attacker.name.includes("fetch'd") && 
-		(attacker.item == "Leek" || attacker.item == "Stick")) { boosts += 2; }
+	if (attacker.name.includes("fetch'd") && (attacker.item == "Leek" || attacker.item == "Stick")) { boosts += 2; }
 	if (attacker.name == "Chansey" && attacker.item == "Lucky Punch") { boosts += 2; }
-	if (aField.isFocusEnergy) { boosts += 2; }
+	if (aField.attackerSide.isFocusEnergy) { boosts += 2; }
 
 	boosts = Math.min(boosts, stages.length-1);
 	

--- a/src/js/crit_rate.js
+++ b/src/js/crit_rate.js
@@ -24,7 +24,6 @@ function strMatch(s, ...matches) {
 
 // TODO: one field probably works with some refactoring
 function getCritRate(attacker, defender, aField, dField, moveIndex, honorCritFlag = true) {
-	console.log(attacker, defender, aField, dField, moveIndex); // DEBUG
 	const move = attacker.moves[moveIndex];
 	const moveName = move.name;
 	const attackerNotInitialized = attacker.item === null || attacker.ability === null || attacker.name === null;

--- a/src/js/index_randoms_controls.js
+++ b/src/js/index_randoms_controls.js
@@ -131,8 +131,10 @@ function performCalculations() {
 
 	damageResults = calculateAllMoves(gen, p1, p1field, p2, p2field);
 	if (typeof updateCritRateLabelsFromPokemon === "function") {
+		console.log("updateCritRateLabelsFromPokemon is a function"); // DEBUG
 		updateCritRateLabelsFromPokemon(p1, p2, p1field, p2field);
 	}
+	
 	p1 = damageResults[0][0].attacker;
 	p2 = damageResults[1][0].attacker;
 	var battling = [p1, p2];

--- a/src/js/index_randoms_controls.js
+++ b/src/js/index_randoms_controls.js
@@ -130,6 +130,9 @@ function performCalculations() {
 	var p2field = p1field.clone().swap();
 
 	damageResults = calculateAllMoves(gen, p1, p1field, p2, p2field);
+	if (typeof updateCritRateLabelsFromPokemon === "function") {
+		updateCritRateLabelsFromPokemon(p1, p2, p1field, p2field);
+	}
 	p1 = damageResults[0][0].attacker;
 	p2 = damageResults[1][0].attacker;
 	var battling = [p1, p2];

--- a/src/js/index_randoms_controls.js
+++ b/src/js/index_randoms_controls.js
@@ -130,7 +130,7 @@ function performCalculations() {
 	var p2field = p1field.clone().swap();
 
 	damageResults = calculateAllMoves(gen, p1, p1field, p2, p2field);
-	if (typeof updateCritRateLabelsFromPokemon === "function") {
+	if (critRateLabelsVisible() && typeof updateCritRateLabelsFromPokemon === "function") {
 		console.log("updateCritRateLabelsFromPokemon is a function"); // DEBUG
 		updateCritRateLabelsFromPokemon(p1, p2, p1field, p2field);
 	}

--- a/src/js/index_randoms_controls.js
+++ b/src/js/index_randoms_controls.js
@@ -131,7 +131,6 @@ function performCalculations() {
 
 	damageResults = calculateAllMoves(gen, p1, p1field, p2, p2field);
 	if (critRateLabelsVisible() && typeof updateCritRateLabelsFromPokemon === "function") {
-		console.log("updateCritRateLabelsFromPokemon is a function"); // DEBUG
 		updateCritRateLabelsFromPokemon(p1, p2, p1field, p2field);
 	}
 	

--- a/src/js/range_compare.js
+++ b/src/js/range_compare.js
@@ -480,7 +480,6 @@ function recalcEntry(entry) {
 		
 		entry.damageRolls = rolls;
 		entry.critRolls = critRolls;
-		console.log(attacker, defender, field, p2field, entry.moveIdx);
 		entry.critRate = getCritRate(attacker, defender, field, p2field, entry.moveIdx);
 		
 		entry.damageRollsStr = entry.damageRolls.join(', ');

--- a/src/js/range_compare.js
+++ b/src/js/range_compare.js
@@ -529,6 +529,7 @@ function recalcEntry(entry) {
 		
 		entry.damageRolls = rolls;
 		entry.critRolls = critRolls;
+		console.log(attacker, defender, field, p2field, entry.moveIdx);
 		entry.critRate = getCritRate(attacker, defender, field, p2field, entry.moveIdx);
 		
 		entry.damageRollsStr = entry.damageRolls.join(', ');

--- a/src/js/range_compare.js
+++ b/src/js/range_compare.js
@@ -13,58 +13,9 @@ window.RangeCompare = {
     chart: null
 };
 
+var getCritRate = window.getCritRate;
+
 LINEBREAK_REGEX = '(\r\n|\r|\n)';
-
-
-var highCritRatioMoveNames = [
-	"Aeroblast", "Air Cutter", "Attack Order",
-	"Blaze Kick", "Crabhammer", "Cross Chop", "Cross Poison", "Drill Run",
-	"Karate Chop", "Leaf Blade", "Night Slash", "Poison Tail", "Psycho Cut",
-	"Razor Leaf", "Razor Wind", "Shadow Claw", "Sky Attack", "Slash",
-	"Spacial Rend", "Stone Edge"
-];
-
-var critBlockingAbilities = [
-	"Shell Armor", "Battle Armor", "Magma Armor"
-]
-
-var highCritRatioItems = [
-	"Razor Claw", "Scope Lens"
-]
-
-function strMatch(s, ...matches) {
-	var match = false;
-	matches.forEach(function(m) {
-		if (s == m) { match = true; }
-	});
-	return match;
-}
-
-function getCritRate(attacker, defender, aField, dField, moveIndex) {
-	if (strMatch(defender.ability, ...critBlockingAbilities) ||
-		(dField.isLuckyChant ?? false)) { return 0; }
-
-	stages = [0.0625, 0.125, 0.5, 1];
-
-	boosts = 0;
-
-	if (strMatch(attacker.moves[moveIndex].originalName, ...highCritRatioMoveNames)) {
-		boosts++;
-	}
-
-	if (strMatch(attacker.item, ...highCritRatioItems)) { boosts++; }
-	if (strMatch(attacker.ability, "Super Luck")) { boosts++; }
-	if (attacker.name.includes("fetch'd") && 
-		(attacker.item == "Leek" || attacker.item == "Stick")) { boosts += 2; }
-	if (attacker.name == "Chansey" && attacker.item == "Lucky Punch") { boosts += 2; }
-	if (aField.isFocusEnergy) { boosts += 2; }
-
-	boosts = Math.min(boosts, stages.length-1);
-	
-	// console.log(`returning ${stages[boosts]}`);
-	return stages[boosts];
-}
-
 
 function removeAllOccurrences(str, substring) {
 	if (!substring) return str;

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -1,3 +1,5 @@
+var getCritRate = window.getCritRate;
+
 var zeroBPButNotStatus = ["Electro Ball", "Metal Burst", "Endeavor", "Bide",
      "Seismic Toss", "Punishment", "Flail", "Reversal", "Gyro Ball", "Magnitude", "Heat Crash",
       "Heavy Slam", "Present", "Natural Gift", "Beat Up", "Fissure", "Guillotine", "Horn Drill", "Super Fang",
@@ -369,16 +371,6 @@ $(".status").bind("keyup change", function () {
 
 var lockerMove = "";
 
-var guaranteedCritHighRatioMoves = [
-	"Aeroblast", "Air Cutter", "Attack Order",
-	"Blaze Kick", "Crabhammer", "Cross Chop", "Cross Poison", "Drill Run",
-	"Karate Chop", "Leaf Blade", "Night Slash", "Poison Tail", "Psycho Cut",
-	"Razor Leaf", "Razor Wind", "Shadow Claw", "Sky Attack", "Slash",
-	"Spacial Rend", "Stone Edge"
-];
-var guaranteedCritItems = ["Razor Claw", "Scope Lens"];
-var critBlockingAbilities = ["Battle Armor", "Shell Armor", "Magma Armor"];
-
 function matchesAny(value, values) {
 	return values.indexOf(value) !== -1;
 }
@@ -386,6 +378,16 @@ function matchesAny(value, values) {
 function getOpposingPokeInfo(pokeInfo) {
 	return pokeInfo.attr("id") === "p1" ? $("#p2") : $("#p1");
 }
+
+$(".crit-btn").click(function()) {
+	const idSuffix = this.id.substr(this.id.length - 2);
+	const critCheckbox = $("#crit" + idSuffix);
+	// TODO: cont from here, finish this, test edge cases, test range compare, update style, create ai setting for configurability
+	$("#critRate" + idSuffix)
+}
+
+// TODO: cont from here
+/*
 
 function getMoveCritRate(move, moveGroupObj) {
 	var attacker = moveGroupObj.closest(".poke-info");
@@ -430,7 +432,7 @@ function getPokemonMoveCritRate(attacker, defender, field, move) {
 	if (field && field.attackerSide && field.attackerSide.isFocusEnergy) boosts += 2;
 
 	return stages[Math.min(boosts, stages.length - 1)];
-}
+} */
 
 function formatCritRate(rate) {
 	if (rate === null) return "";
@@ -454,8 +456,8 @@ function updateCritRateLabelById(idSuffix, rate) {
 function updateCritRateLabelsFromPokemon(p1, p2, p1field, p2field) {
 	console.log(p1, p2, p1field, p2field);
 	for (var i = 0; i < 4; i++) {
-		updateCritRateLabelById("L" + (i + 1), getCritRate(p1, p2, p1field, p1.moves[i]));
-		updateCritRateLabelById("R" + (i + 1), getCritRate(p2, p1, p2field, p2.moves[i]));
+		updateCritRateLabelById("L" + (i + 1), getCritRate(p1, p2, p1field, p2field, i));
+		updateCritRateLabelById("R" + (i + 1), getCritRate(p2, p1, p2field, p1field, i));
 	}
 }
 
@@ -470,7 +472,8 @@ function updateGuaranteedCritForMove(moveGroupObj, clearNonGuaranteed) {
 	var move = moves[moveName] || moves['(No Move)'];
 	var crit = moveGroupObj.children(".move-crit");
 	// change to new
-	var critRate = getCritRate(move, moveGroupObj);
+	// var critRate = getCritRate(move, moveGroupObj);
+	var critRate = 0.0625;
 	updateCritRateLabel(moveGroupObj, critRate);
 
 	if (critRate === 1) {

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -379,27 +379,44 @@ function getOpposingPokeInfo(pokeInfo) {
 	return pokeInfo.attr("id") === "p1" ? $("#p2") : $("#p1");
 }
 
-function formatCritRate(rate) {
+function formatCritRateValue(rate) {
 	if (rate === null) return "";
 	var percent = rate * 100;
-	return (percent % 1 === 0 ? percent.toFixed(0) : percent.toString()) + "%";
+	return percent % 1 === 0 ? percent.toFixed(0) : percent.toString();
+}
+
+function critRateLabelsVisible() {
+	var $toggle = $("#showCritPercentages");
+	return !$toggle.length || $toggle.is(":checked");
+}
+
+function critRateLabelHtml(labelId) {
+	return '<span class="crit-rate" id="' + labelId + '">' +
+		'<span class="crit-rate-value"></span><span class="crit-rate-sign">%</span></span>';
+}
+
+function ensureCritRateLabelStructure($label) {
+	if (!$label.find(".crit-rate-value").length) {
+		$label.html('<span class="crit-rate-value"></span><span class="crit-rate-sign">%</span>');
+	}
 }
 
 function updateCritRateLabel(moveGroupObj, rate) {
 	var idSuffix = moveGroupObj.children(".move-crit").attr("id").substr(4);
-	var text = formatCritRate(rate);
-	var hidden = text === "";
-	$("#critRate" + idSuffix).text(text).toggle(!hidden);
+	updateCritRateLabelById(idSuffix, rate);
 }
 
 function updateCritRateLabelById(idSuffix, rate) {
-	var text = formatCritRate(rate);
-	var hidden = text === "";
-	$("#critRate" + idSuffix).text(text).toggle(!hidden);
+	if (!critRateLabelsVisible()) return;
+	var $label = $("#critRate" + idSuffix);
+	if (!$label.length) return;
+	ensureCritRateLabelStructure($label);
+	var value = formatCritRateValue(rate);
+	$label.find(".crit-rate-value").text(value);
+	$label.toggle(value !== "");
 }
 
 function updateCritRateLabelsFromPokemon(p1, p2, p1field, p2field) {
-	console.log(p1, p2, p1field, p2field);
 	for (var i = 0; i < 4; i++) {
 		updateCritRateLabelById("L" + (i + 1), getCritRate(p1, p2, p1field, p2field, i));
 		updateCritRateLabelById("R" + (i + 1), getCritRate(p2, p1, p2field, p1field, i));
@@ -412,29 +429,13 @@ function setCritCheckbox(moveGroupObj, checked, autoCrit) {
 	crit.prop("checked", checked).change();
 }
 
-function updateGuaranteedCritForMove(moveGroupObj, clearNonGuaranteed) {
-	var moveName = moveGroupObj.children(".move-selector").val();
-	var move = moves[moveName] || moves['(No Move)'];
-	var crit = moveGroupObj.children(".move-crit");
-	// change to new
-	// var critRate = getCritRate(move, moveGroupObj);
-	var critRate = 0.0625;
-	updateCritRateLabel(moveGroupObj, critRate);
-
-	if (critRate === 1) {
-		setCritCheckbox(moveGroupObj, true, true);
-	} else if (clearNonGuaranteed || crit.data("autoCrit")) {
-		setCritCheckbox(moveGroupObj, false, false);
-	}
-}
-
 function ensureCritRateLabels(showCritPercentages) {
 	if (showCritPercentages) {
 		$(".move-crit").each(function () {
 			var idSuffix = this.id.substr(4);
 			var labelId = "critRate" + idSuffix;
 			if (!$("#" + labelId).length) {
-				$(this).next(".crit-btn").after('<span class="crit-rate" id="' + labelId + '"></span>');
+				$(this).next(".crit-btn").after(critRateLabelHtml(labelId));
 			}
 		});
 	} else {
@@ -442,21 +443,26 @@ function ensureCritRateLabels(showCritPercentages) {
 	}
 }
 
-function updateGuaranteedCrits() {
-	$(".i-f-move, .i-f-o-move").each(function () {
-		updateGuaranteedCritForMove($(this), false);
-	});
+function populateCritRateLabels() {
+	var p1info = $("#p1");
+	var p2info = $("#p2");
+	if (!p1info.length || !p2info.length) return;
+	var p1 = createPokemon(p1info);
+	var p2 = createPokemon(p2info);
+	var p1field = createField();
+	updateCritRateLabelsFromPokemon(p1, p2, p1field, p1field.clone().swap());
 }
 
 function refreshCritRateLabels() {
-	ensureCritRateLabels($("#showCritPercentages").is(":checked"));
+	var showCritPercentages = critRateLabelsVisible();
+	$("body").toggleClass("show-crit-percentages", showCritPercentages);
+	ensureCritRateLabels(showCritPercentages);
+	if (showCritPercentages) {
+		populateCritRateLabels();
+	}
 }
 
-$("#showCritPercentages").change(function() {
-	var showCritPercentages = $(this).is(":checked");
-	console.log("showCritPercentages", showCritPercentages);
-	ensureCritRateLabels(showCritPercentages);
-});
+$(document).on("change", "#showCritPercentages", refreshCritRateLabels);
 
 // auto-update move details on select
 $(".move-selector").change(function () {

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -379,61 +379,6 @@ function getOpposingPokeInfo(pokeInfo) {
 	return pokeInfo.attr("id") === "p1" ? $("#p2") : $("#p1");
 }
 
-$(".crit-btn").click(function()) {
-	const idSuffix = this.id.substr(this.id.length - 2);
-	const critCheckbox = $("#crit" + idSuffix);
-	// TODO: cont from here, finish this, test edge cases, test range compare, update style, create ai setting for configurability
-	$("#critRate" + idSuffix)
-}
-
-// TODO: cont from here
-/*
-
-function getMoveCritRate(move, moveGroupObj) {
-	var attacker = moveGroupObj.closest(".poke-info");
-	var defender = getOpposingPokeInfo(attacker);
-	var attackerSide = attacker.attr("id") === "p1" ? "L" : "R";
-	var moveName = move.name || moveGroupObj.children(".move-selector").val();
-	var defenderAbility = defender.find(".ability").val();
-	if (move.category === "Status" || moveName === "(No Move)") return null;
-	if (matchesAny(defenderAbility, autoCritBlockingAbilities)) return 0;
-	if (move.willCrit === true) return 1;
-
-	var ability = attacker.find(".ability").val();
-	var item = attacker.find(".item").val();
-	var species = attacker.find(".set-selector").val() || "";
-	var boosts = 0;
-	var stages = [0.0625, 0.125, 0.5, 1];
-
-	if (matchesAny(moveName, guaranteedCritHighRatioMoves)) boosts++;
-	if (matchesAny(item, guaranteedCritItems)) boosts++;
-	if (ability === "Super Luck") boosts++;
-	if (species.includes("fetch'd") && (item === "Leek" || item === "Stick")) boosts += 2;
-	if (species.indexOf("Chansey") === 0 && item === "Lucky Punch") boosts += 2;
-	if ($("#focusEnergy" + attackerSide).prop("checked")) boosts += 2;
-
-	return stages[Math.min(boosts, stages.length - 1)];
-}
-
-function getPokemonMoveCritRate(attacker, defender, field, move) {
-	var moveName = move.name || move.originalName;
-	if (move.category === "Status" || moveName === "(No Move)" || !move.bp) return null;
-	if (defender.hasAbility && defender.hasAbility("Battle Armor", "Shell Armor", "Magma Armor")) return 0;
-	if (move.isCrit) return 1;
-
-	var boosts = 0;
-	var stages = [0.0625, 0.125, 0.5, 1];
-
-	if (matchesAny(moveName, guaranteedCritHighRatioMoves)) boosts++;
-	if (matchesAny(attacker.item, guaranteedCritItems)) boosts++;
-	if (attacker.hasAbility && attacker.hasAbility("Super Luck")) boosts++;
-	if (attacker.name.includes("fetch'd") && (attacker.item === "Leek" || attacker.item === "Stick")) boosts += 2;
-	if (attacker.name === "Chansey" && attacker.item === "Lucky Punch") boosts += 2;
-	if (field && field.attackerSide && field.attackerSide.isFocusEnergy) boosts += 2;
-
-	return stages[Math.min(boosts, stages.length - 1)];
-} */
-
 function formatCritRate(rate) {
 	if (rate === null) return "";
 	var percent = rate * 100;
@@ -483,14 +428,18 @@ function updateGuaranteedCritForMove(moveGroupObj, clearNonGuaranteed) {
 	}
 }
 
-function ensureCritRateLabels() {
-	$(".move-crit").each(function () {
-		var idSuffix = this.id.substr(4);
-		var labelId = "critRate" + idSuffix;
-		if (!$("#" + labelId).length) {
-			$(this).next(".crit-btn").after('<span class="crit-rate" id="' + labelId + '"></span>');
-		}
-	});
+function ensureCritRateLabels(showCritPercentages) {
+	if (showCritPercentages) {
+		$(".move-crit").each(function () {
+			var idSuffix = this.id.substr(4);
+			var labelId = "critRate" + idSuffix;
+			if (!$("#" + labelId).length) {
+				$(this).next(".crit-btn").after('<span class="crit-rate" id="' + labelId + '"></span>');
+			}
+		});
+	} else {
+		$(".crit-rate").remove();
+	}
 }
 
 function updateGuaranteedCrits() {
@@ -500,9 +449,14 @@ function updateGuaranteedCrits() {
 }
 
 function refreshCritRateLabels() {
-	ensureCritRateLabels();
-	updateGuaranteedCrits();
+	ensureCritRateLabels($("#showCritPercentages").is(":checked"));
 }
+
+$("#showCritPercentages").change(function() {
+	var showCritPercentages = $(this).is(":checked");
+	console.log("showCritPercentages", showCritPercentages);
+	ensureCritRateLabels(showCritPercentages);
+});
 
 // auto-update move details on select
 $(".move-selector").change(function () {

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -246,7 +246,6 @@ $(".ability").bind("keyup change", function () {
 	} else {
 		$(this).closest(".poke-info").find(".alliesFainted").val('0');
 		$(this).closest(".poke-info").find(".alliesFainted").hide();
-
 	}
 });
 
@@ -370,69 +369,6 @@ $(".status").bind("keyup change", function () {
 
 var lockerMove = "";
 
-var guaranteedCritHighRatioMoves = [
-	"Aeroblast", "Air Cutter", "Attack Order",
-	"Blaze Kick", "Crabhammer", "Cross Chop", "Cross Poison", "Drill Run",
-	"Karate Chop", "Leaf Blade", "Night Slash", "Poison Tail", "Psycho Cut",
-	"Razor Leaf", "Razor Wind", "Shadow Claw", "Sky Attack", "Slash",
-	"Spacial Rend", "Stone Edge"
-];
-var guaranteedCritItems = ["Razor Claw", "Scope Lens"];
-var critBlockingAbilities = ["Battle Armor", "Shell Armor", "Magma Armor"];
-
-function matchesAny(value, values) {
-	return values.indexOf(value) !== -1;
-}
-
-function getOpposingPokeInfo(pokeInfo) {
-	return pokeInfo.attr("id") === "p1" ? $("#p2") : $("#p1");
-}
-
-function getMoveCritRate(move, moveGroupObj) {
-	var attacker = moveGroupObj.closest(".poke-info");
-	var defender = getOpposingPokeInfo(attacker);
-	var attackerSide = attacker.attr("id") === "p1" ? "L" : "R";
-	var moveName = move.name || moveGroupObj.children(".move-selector").val();
-	var defenderAbility = defender.find(".ability").val();
-	if (move.category === "Status" || moveName === "(No Move)") return null;
-	if (matchesAny(defenderAbility, autoCritBlockingAbilities)) return 0;
-	if (move.willCrit === true) return 1;
-
-	var ability = attacker.find(".ability").val();
-	var item = attacker.find(".item").val();
-	var species = attacker.find(".set-selector").val() || "";
-	var boosts = 0;
-	var stages = [0.0625, 0.125, 0.5, 1];
-
-	if (matchesAny(moveName, guaranteedCritHighRatioMoves)) boosts++;
-	if (matchesAny(item, guaranteedCritItems)) boosts++;
-	if (ability === "Super Luck") boosts++;
-	if (species.includes("fetch'd") && (item === "Leek" || item === "Stick")) boosts += 2;
-	if (species.indexOf("Chansey") === 0 && item === "Lucky Punch") boosts += 2;
-	if ($("#focusEnergy" + attackerSide).prop("checked")) boosts += 2;
-
-	return stages[Math.min(boosts, stages.length - 1)];
-}
-
-function getPokemonMoveCritRate(attacker, defender, field, move) {
-	var moveName = move.name || move.originalName;
-	if (move.category === "Status" || moveName === "(No Move)" || !move.bp) return null;
-	if (defender.hasAbility && defender.hasAbility("Battle Armor", "Shell Armor", "Magma Armor")) return 0;
-	if (move.isCrit) return 1;
-
-	var boosts = 0;
-	var stages = [0.0625, 0.125, 0.5, 1];
-
-	if (matchesAny(moveName, guaranteedCritHighRatioMoves)) boosts++;
-	if (matchesAny(attacker.item, guaranteedCritItems)) boosts++;
-	if (attacker.hasAbility && attacker.hasAbility("Super Luck")) boosts++;
-	if (attacker.name.includes("fetch'd") && (attacker.item === "Leek" || attacker.item === "Stick")) boosts += 2;
-	if (attacker.name === "Chansey" && attacker.item === "Lucky Punch") boosts += 2;
-	if (field && field.attackerSide && field.attackerSide.isFocusEnergy) boosts += 2;
-
-	return stages[Math.min(boosts, stages.length - 1)];
-}
-
 function formatCritRate(rate) {
 	if (rate === null) return "";
 	var percent = rate * 100;
@@ -453,9 +389,10 @@ function updateCritRateLabelById(idSuffix, rate) {
 }
 
 function updateCritRateLabelsFromPokemon(p1, p2, p1field, p2field) {
+	console.log(p1, p2, p1field, p2field);
 	for (var i = 0; i < 4; i++) {
-		updateCritRateLabelById("L" + (i + 1), getPokemonMoveCritRate(p1, p2, p1field, p1.moves[i]));
-		updateCritRateLabelById("R" + (i + 1), getPokemonMoveCritRate(p2, p1, p2field, p2.moves[i]));
+		updateCritRateLabelById("L" + (i + 1), getCritRate(p1, p2, p1field, p1.moves[i]));
+		updateCritRateLabelById("R" + (i + 1), getCritRate(p2, p1, p2field, p2.moves[i]));
 	}
 }
 
@@ -469,7 +406,8 @@ function updateGuaranteedCritForMove(moveGroupObj, clearNonGuaranteed) {
 	var moveName = moveGroupObj.children(".move-selector").val();
 	var move = moves[moveName] || moves['(No Move)'];
 	var crit = moveGroupObj.children(".move-crit");
-	var critRate = getMoveCritRate(move, moveGroupObj);
+	// change to new
+	var critRate = getCritRate(move, moveGroupObj);
 	updateCritRateLabel(moveGroupObj, critRate);
 
 	if (critRate === 1) {

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -395,7 +395,7 @@ function getMoveCritRate(move, moveGroupObj) {
 	var moveName = move.name || moveGroupObj.children(".move-selector").val();
 	var defenderAbility = defender.find(".ability").val();
 	if (move.category === "Status" || moveName === "(No Move)") return null;
-	if (matchesAny(defenderAbility, autoCritBlockingAbilities)) return 0;
+	if (matchesAny(defenderAbility, critBlockingAbilities)) return 0;
 	if (move.willCrit === true) return 1;
 
 	var ability = attacker.find(".ability").val();

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -369,6 +369,137 @@ $(".status").bind("keyup change", function () {
 });
 
 var lockerMove = "";
+
+var guaranteedCritHighRatioMoves = [
+	"Aeroblast", "Air Cutter", "Attack Order",
+	"Blaze Kick", "Crabhammer", "Cross Chop", "Cross Poison", "Drill Run",
+	"Karate Chop", "Leaf Blade", "Night Slash", "Poison Tail", "Psycho Cut",
+	"Razor Leaf", "Razor Wind", "Shadow Claw", "Sky Attack", "Slash",
+	"Spacial Rend", "Stone Edge"
+];
+var guaranteedCritItems = ["Razor Claw", "Scope Lens"];
+var critBlockingAbilities = ["Battle Armor", "Shell Armor", "Magma Armor"];
+
+function matchesAny(value, values) {
+	return values.indexOf(value) !== -1;
+}
+
+function getOpposingPokeInfo(pokeInfo) {
+	return pokeInfo.attr("id") === "p1" ? $("#p2") : $("#p1");
+}
+
+function getMoveCritRate(move, moveGroupObj) {
+	var attacker = moveGroupObj.closest(".poke-info");
+	var defender = getOpposingPokeInfo(attacker);
+	var attackerSide = attacker.attr("id") === "p1" ? "L" : "R";
+	var moveName = move.name || moveGroupObj.children(".move-selector").val();
+	var defenderAbility = defender.find(".ability").val();
+	if (move.category === "Status" || moveName === "(No Move)") return null;
+	if (matchesAny(defenderAbility, autoCritBlockingAbilities)) return 0;
+	if (move.willCrit === true) return 1;
+
+	var ability = attacker.find(".ability").val();
+	var item = attacker.find(".item").val();
+	var species = attacker.find(".set-selector").val() || "";
+	var boosts = 0;
+	var stages = [0.0625, 0.125, 0.5, 1];
+
+	if (matchesAny(moveName, guaranteedCritHighRatioMoves)) boosts++;
+	if (matchesAny(item, guaranteedCritItems)) boosts++;
+	if (ability === "Super Luck") boosts++;
+	if (species.includes("fetch'd") && (item === "Leek" || item === "Stick")) boosts += 2;
+	if (species.indexOf("Chansey") === 0 && item === "Lucky Punch") boosts += 2;
+	if ($("#focusEnergy" + attackerSide).prop("checked")) boosts += 2;
+
+	return stages[Math.min(boosts, stages.length - 1)];
+}
+
+function getPokemonMoveCritRate(attacker, defender, field, move) {
+	var moveName = move.name || move.originalName;
+	if (move.category === "Status" || moveName === "(No Move)" || !move.bp) return null;
+	if (defender.hasAbility && defender.hasAbility("Battle Armor", "Shell Armor", "Magma Armor")) return 0;
+	if (move.isCrit) return 1;
+
+	var boosts = 0;
+	var stages = [0.0625, 0.125, 0.5, 1];
+
+	if (matchesAny(moveName, guaranteedCritHighRatioMoves)) boosts++;
+	if (matchesAny(attacker.item, guaranteedCritItems)) boosts++;
+	if (attacker.hasAbility && attacker.hasAbility("Super Luck")) boosts++;
+	if (attacker.name.includes("fetch'd") && (attacker.item === "Leek" || attacker.item === "Stick")) boosts += 2;
+	if (attacker.name === "Chansey" && attacker.item === "Lucky Punch") boosts += 2;
+	if (field && field.attackerSide && field.attackerSide.isFocusEnergy) boosts += 2;
+
+	return stages[Math.min(boosts, stages.length - 1)];
+}
+
+function formatCritRate(rate) {
+	if (rate === null) return "";
+	var percent = rate * 100;
+	return (percent % 1 === 0 ? percent.toFixed(0) : percent.toString()) + "%";
+}
+
+function updateCritRateLabel(moveGroupObj, rate) {
+	var idSuffix = moveGroupObj.children(".move-crit").attr("id").substr(4);
+	var text = formatCritRate(rate);
+	var hidden = text === "";
+	$("#critRate" + idSuffix).text(text).toggle(!hidden);
+}
+
+function updateCritRateLabelById(idSuffix, rate) {
+	var text = formatCritRate(rate);
+	var hidden = text === "";
+	$("#critRate" + idSuffix).text(text).toggle(!hidden);
+}
+
+function updateCritRateLabelsFromPokemon(p1, p2, p1field, p2field) {
+	for (var i = 0; i < 4; i++) {
+		updateCritRateLabelById("L" + (i + 1), getPokemonMoveCritRate(p1, p2, p1field, p1.moves[i]));
+		updateCritRateLabelById("R" + (i + 1), getPokemonMoveCritRate(p2, p1, p2field, p2.moves[i]));
+	}
+}
+
+function setCritCheckbox(moveGroupObj, checked, autoCrit) {
+	var crit = moveGroupObj.children(".move-crit");
+	crit.data("autoCrit", autoCrit);
+	crit.prop("checked", checked).change();
+}
+
+function updateGuaranteedCritForMove(moveGroupObj, clearNonGuaranteed) {
+	var moveName = moveGroupObj.children(".move-selector").val();
+	var move = moves[moveName] || moves['(No Move)'];
+	var crit = moveGroupObj.children(".move-crit");
+	var critRate = getMoveCritRate(move, moveGroupObj);
+	updateCritRateLabel(moveGroupObj, critRate);
+
+	if (critRate === 1) {
+		setCritCheckbox(moveGroupObj, true, true);
+	} else if (clearNonGuaranteed || crit.data("autoCrit")) {
+		setCritCheckbox(moveGroupObj, false, false);
+	}
+}
+
+function ensureCritRateLabels() {
+	$(".move-crit").each(function () {
+		var idSuffix = this.id.substr(4);
+		var labelId = "critRate" + idSuffix;
+		if (!$("#" + labelId).length) {
+			$(this).next(".crit-btn").after('<span class="crit-rate" id="' + labelId + '"></span>');
+		}
+	});
+}
+
+function updateGuaranteedCrits() {
+	$(".i-f-move, .i-f-o-move").each(function () {
+		updateGuaranteedCritForMove($(this), false);
+	});
+}
+
+function refreshCritRateLabels() {
+	ensureCritRateLabels();
+	updateGuaranteedCrits();
+}
+
 // auto-update move details on select
 $(".move-selector").change(function () {
 	var moveName = $(this).val();
@@ -653,6 +784,7 @@ $(".set-selector").change(function () {
 		calcStats(pokeObj);
 		abilityObj.change();
 		itemObj.change();
+		refreshCritRateLabels();
 		if (pokemon.gender === "N") {
 			pokeObj.find(".gender").parent().hide();
 			pokeObj.find(".gender").val("");
@@ -2141,6 +2273,7 @@ $(document).ready(function () {
 	});
 	$(".set-selector").val(getFirstValidSetOption().id);
 	$(".set-selector").change();
+	refreshCritRateLabels();
 	$(".terrain-trigger").bind("change keyup", getTerrainEffects);
 	$("#previous-trainer").click(previousTrainer);
 	$("#next-trainer").click(nextTrainer);

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -464,6 +464,12 @@ function refreshCritRateLabels() {
 
 $(document).on("change", "#showCritPercentages", refreshCritRateLabels);
 
+$(".crit-rate").on("click", function () {
+	var suffix = this.id.substr(this.id.length - 2);
+	var $crit = $("#crit" + suffix);
+	$crit.click();
+});
+
 // auto-update move details on select
 $(".move-selector").change(function () {
 	var moveName = $(this).val();


### PR DESCRIPTION
Added crit-rate percentage indicators to the UI. Now displays the calculated critical hit chance (6.25%, 12.5%, 50%, or 100%) next to the crit buttons using the same logic as the auto-toggle-crit system. Rates update dynamically based on moves, abilities, items, and Focus Energy, are hidden for invalid move slots, and correctly show 0% when crits are prevented by the target's ability.