### PR TITLE
Add HP action buttons and handlers

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -640,6 +640,18 @@ button svg {
 .info-group {
     margin: 1em 0;
 }
+.hp-actions {
+    display: flex;
+    justify-content: left;
+    gap: 2px;
+    margin-top: 4px;
+}
+.hp-action {
+    font-size: 0.8em;
+    line-height: 1.2;
+    min-width: 4.25em;
+    padding: 2px 4px;
+}
 .set-selector {
     width: 100%;
 }

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -696,6 +696,12 @@
                     <label for="currentHpL1">Current HP</label>
                     <input class="current-hp calc-trigger" id="currentHpL1" value="341" />/<span class="max-hp">341</span> (
                     <input class="percent-hp calc-trigger" value="100">%)</input>
+                    <div class="hp-actions" aria-label="Apply HP tick or heal">
+                        <button type="button" class="hp-action" data-hp-numerator="1" data-hp-denominator="4" title="Heal 1/4 max HP">Sitrus</button>
+                        <button type="button" class="hp-action" data-hp-numerator="-1" data-hp-denominator="16" title="Take 1/16 max HP">Burn</button>
+                        <button type="button" class="hp-action" data-hp-numerator="-1" data-hp-denominator="8" title="Take 1/8 max HP">Poison</button>
+                        <button type="button" class="hp-action" data-hp-numerator="-1" data-hp-denominator="16" title="Take 1/16 max HP">Sand</button>
+                    </div>
                     <br />
                     <br />
                     Health <div class="hpbar"></div>
@@ -1654,6 +1660,12 @@
                     <label for="currentHpR1">Current HP</label>
                     <input class="current-hp calc-trigger" id="currentHpR1" value="341" />/<span class="max-hp">341</span> (
                     <input class="percent-hp calc-trigger" value="100" />%)
+                    <div class="hp-actions" aria-label="Apply HP tick or heal">
+                        <button type="button" class="hp-action" data-hp-numerator="1" data-hp-denominator="4" title="Heal 1/4 max HP">Sitrus</button>
+                        <button type="button" class="hp-action" data-hp-numerator="-1" data-hp-denominator="16" title="Take 1/16 max HP">Burn</button>
+                        <button type="button" class="hp-action" data-hp-numerator="-1" data-hp-denominator="8" title="Take 1/8 max HP">Poison</button>
+                        <button type="button" class="hp-action" data-hp-numerator="-1" data-hp-denominator="16" title="Take 1/16 max HP">Sand</button>
+                    </div>
                     <br />
                     <br />
                     Health <div class="hpbar"></div>

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -227,6 +227,30 @@ $(".percent-hp").keyup(function () {
 	var percent = $(this).val();
 	calcCurrentHP($(this).parent(), max, percent);
 });
+function getHpActionAmount(max, numerator, denominator) {
+	var amount = Math.floor(max * Math.abs(numerator) / denominator);
+	if (amount < 1 && max > 0) {
+		amount = 1;
+	}
+
+	return numerator < 0 ? -amount : amount;
+}
+$(".hp-action").click(function () {
+	var poke = $(this).closest(".poke-info");
+	var max = Number(poke.find(".max-hp").text());
+	var currentHP = poke.find(".current-hp");
+	var current = Number(currentHP.val());
+	var numerator = Number($(this).attr("data-hp-numerator"));
+	var denominator = Number($(this).attr("data-hp-denominator"));
+
+	if (!max || !denominator) {
+		return;
+	}
+
+	var next = current + getHpActionAmount(max, numerator, denominator);
+	currentHP.val(Math.min(max, Math.max(0, next)));
+	currentHP.keyup();
+});
 
 $(".ability").bind("keyup change", function () {
 	$(this).closest(".poke-info").find(".move-hits").val($(this).val() === 'Skill Link' ? 5 : 3);


### PR DESCRIPTION
Added HP action buttons beneath each Pokémon’s Current HP field. These shortcuts apply common battle HP changes (Sitrus Berry recovery, burn, poison, and sandstorm damage), automatically updating HP values, health bars, percentages, and damage calculations while respecting minimum and maximum HP limits.